### PR TITLE
Fix message sen on file upload

### DIFF
--- a/live_test.go
+++ b/live_test.go
@@ -32,9 +32,9 @@ func TestSendMessage(t *testing.T) {
 	event := Event{}
 	checksum := Checksum{}
 	event.Username = "Dummy"
-	checksum.Type = "etag"
+	checksum.Type = "md5"
 	checksum.Value = "123456789"
-	event.Checksum = checksum
+	event.Checksum = []interface{}{checksum}
 
 	assert.NotPanics(t, func() { messenger.SendMessage(event) })
 

--- a/messenger.go
+++ b/messenger.go
@@ -18,11 +18,11 @@ type Checksum struct {
 
 // The Event struct
 type Event struct {
-	Operation string   `json:"operation"`
-	Username  string   `json:"user"`
-	Filepath  string   `json:"filepath"`
-	Filesize  int64    `json:"filesize"`
-	Checksum  Checksum `json:"encoded_checksum"`
+	Operation string        `json:"operation"`
+	Username  string        `json:"user"`
+	Filepath  string        `json:"filepath"`
+	Filesize  int64         `json:"filesize"`
+	Checksum  []interface{} `json:"encrypted_checksums"`
 }
 
 // Messenger is an interface for sending messages for different file events

--- a/proxy.go
+++ b/proxy.go
@@ -280,9 +280,9 @@ func (p *Proxy) CreateMessageFromRequest(r *http.Request) (Event, error) {
 	}
 	event.Filepath = r.URL.Path
 	event.Username = username
-	checksum.Type = "etag"
-	event.Checksum = checksum
-	log.Info("user ", event.Username, " uploaded file ", event.Filepath, " with checksum ", event.Checksum.Value, " at ", time.Now())
+	checksum.Type = "md5"
+	event.Checksum = []interface{}{checksum}
+	log.Info("user ", event.Username, " uploaded file ", event.Filepath, " with checksum ", checksum.Value, " at ", time.Now())
 	return event, nil
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"crypto/tls"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -270,14 +269,7 @@ func (p *Proxy) CreateMessageFromRequest(r *http.Request) (Event, error) {
 	}
 
 	// Case for simple upload
-	if r.Method == http.MethodPut {
-		event.Operation = "upload"
-		// Case for multi-part upload
-	} else if r.Method == http.MethodPost {
-		event.Operation = "multipart-upload"
-	} else {
-		return Event{}, fmt.Errorf("upload method has to be POST or PUT")
-	}
+	event.Operation = "upload"
 	event.Filepath = r.URL.Path
 	event.Username = username
 	checksum.Type = "md5"


### PR DESCRIPTION
Even though sha256 is preferred the backend only gives us MD5 so that's what we have to work with.
Fixes #70 