### PR TITLE
Fix verify peer config

### DIFF
--- a/config.go
+++ b/config.go
@@ -115,12 +115,14 @@ func (c *Config) readConfig() {
 	}
 	if viper.IsSet("broker.verifyPeer") {
 		b.verifyPeer = viper.GetBool("broker.verifyPeer")
-		// Since verifyPeer is specified, these are required.
-		if !(viper.IsSet("broker.clientCert") && viper.IsSet("broker.clientKey")) {
-			log.Panic("when broker.verifyPeer is set both broker.clientCert and broker.clientKey is needed")
+		if b.verifyPeer {
+			// Since verifyPeer is specified, these are required.
+			if !(viper.IsSet("broker.clientCert") && viper.IsSet("broker.clientKey")) {
+				log.Panicln("when broker.verifyPeer is set both broker.clientCert and broker.clientKey is needed")
+			}
+			b.clientCert = viper.GetString("broker.clientCert")
+			b.clientKey = viper.GetString("broker.clientKey")
 		}
-		b.clientCert = viper.GetString("broker.clientCert")
-		b.clientKey = viper.GetString("broker.clientKey")
 	}
 	if viper.IsSet("broker.cacert") {
 		b.cacert = viper.GetString("broker.cacert")


### PR DESCRIPTION
The verify peer flag needs to be evaluated whether it was set to true to check whether certs are needed.